### PR TITLE
Change the rabbit_peer_discovery_k8s.hrl path

### DIFF
--- a/src/rabbit_peer_discovery_k8s.erl
+++ b/src/rabbit_peer_discovery_k8s.erl
@@ -20,7 +20,7 @@
 
 -include_lib("rabbit_common/include/rabbit.hrl").
 -include_lib("rabbitmq_peer_discovery_common/include/rabbit_peer_discovery.hrl").
--include_lib("rabbitmq_peer_discovery_k8s/include/rabbit_peer_discovery_k8s.hrl").
+-include_lib("../include/rabbit_peer_discovery_k8s.hrl").
 
 -export([list_nodes/0, supports_registration/0, register/0, unregister/0,
          post_registration/0, lock/1, unlock/1]).


### PR DESCRIPTION
By cloning a new repository:


```
git clone https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s.git
cd rabbitmq-peer-discovery-k8s
gmake
```

got this error:
```
src/rabbit_peer_discovery_k8s.erl:23: can't find include lib "rabbitmq_peer_discovery_k8s/include/rabbit_peer_discovery_k8s.hrl"
src/rabbit_peer_discovery_k8s.erl:93: undefined macro 'CONFIG_MAPPING'
src/rabbit_peer_discovery_k8s.erl:89: spec for undefined function get_config_key/2
src/rabbit_peer_discovery_k8s.erl:101: function get_config_key/2 undefined
src/rabbit_peer_discovery_k8s.erl:104: function get_config_key/2 undefined
``` 


should be the path [relative](https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s/blob/rabbitmq-peer-discovery-k8s_change_library_path/src/rabbit_peer_discovery_k8s.erl#L23)?
