### PR TITLE
Example deploy on k8s using StatefulSet Controller

### DIFF
--- a/examples/k8s_statefulsets/README.md
+++ b/examples/k8s_statefulsets/README.md
@@ -1,0 +1,66 @@
+RabbitMQ-Autocluster on K8s  [StatefulSet  Controller](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)   
+
+1. Install [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+
+2. Install [`minikube`](https://kubernetes.io/docs/tasks/tools/install-minikube/)
+
+
+3. Start `minikube` virtual machine:
+```
+$ minikube start --cpus=2 --memory=2040 --vm-driver=virtualbox
+```
+
+4. Create a namespace only for RabbitMQ test:
+```
+$ kubectl create namespace test-rabbitmq
+```
+
+5. Deploy the service `YAML` file:
+
+```
+$ kubectl create -f examples/k8s_statefulsets/rabbitmq-service.yaml
+```
+6. Deploy the RabbitMQ StatefulSet `YAML` file:
+
+```
+$ kubectl create -f examples/k8s_statefulsets/rabbitmq.yaml
+```
+7. Check the cluster status:
+
+Wait  few seconds....then 
+
+```
+$ FIRST_POD=$(kubectl get pods --namespace test-rabbitmq -l 'app=rabbitmq' -o jsonpath='{.items[0].metadata.name }')
+kubectl exec --namespace=test-rabbitmq $FIRST_POD rabbitmqctl cluster_status
+```
+as result you should have:
+```
+Cluster status of node 'rabbit@172.17.0.2'
+[{nodes,[{disc,['rabbit@172.17.0.2','rabbit@172.17.0.4',
+                'rabbit@172.17.0.5']}]},
+ {running_nodes,['rabbit@172.17.0.5','rabbit@172.17.0.4','rabbit@172.17.0.2']},
+ {cluster_name,<<"rabbit@rabbitmq-0.rabbitmq.test-rabbitmq.svc.cluster.local">>},
+ {partitions,[]},
+ {alarms,[{'rabbit@172.17.0.5',[]},
+          {'rabbit@172.17.0.4',[]},
+          {'rabbit@172.17.0.2',[]}]}]
+```
+
+8. Get your `minikube` ip:
+```
+$ minikube ip
+192.168.99.104
+```
+9. Ports:
+	* `http://<<minikube_ip>>:31672` - Management UI
+	* `amqp://guest:guest@<<minikube_ip>>:30672` - AMQP
+
+10. Scaling:
+```
+$ kubectl scale statefulset/rabbitmq --namespace=test-rabbitmq --replicas=5
+```
+
+
+
+

--- a/examples/k8s_statefulsets/README.md
+++ b/examples/k8s_statefulsets/README.md
@@ -1,4 +1,5 @@
-RabbitMQ-Autocluster on K8s  [StatefulSet  Controller](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)   
+The example shows how to deploy RabbitMQ on K8s [StatefulSet  Controller](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/). It uses the Pivotal Docker image: [pivotalrabbitmq/rabbitmq-autocluster:3.7-k8s-BETA](https://hub.docker.com/r/pivotalrabbitmq/rabbitmq-autocluster/)  
+
 
 1. Install [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 

--- a/examples/k8s_statefulsets/README.md
+++ b/examples/k8s_statefulsets/README.md
@@ -1,5 +1,6 @@
-The example shows how to deploy RabbitMQ on K8s [StatefulSet  Controller](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/). It uses the Pivotal Docker image: [pivotalrabbitmq/rabbitmq-autocluster:3.7-k8s-BETA](https://hub.docker.com/r/pivotalrabbitmq/rabbitmq-autocluster/)  
-
+The example shows how to deploy RabbitMQ on K8s using [StatefulSet  Controller](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/). 
+----
+The example uses Pivotal Docker image: [pivotalrabbitmq/rabbitmq-autocluster:3.7-k8s-BETA](https://hub.docker.com/r/pivotalrabbitmq/rabbitmq-autocluster/)  
 
 1. Install [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 

--- a/examples/k8s_statefulsets/rabbitmq-service.yaml
+++ b/examples/k8s_statefulsets/rabbitmq-service.yaml
@@ -1,0 +1,23 @@
+kind: Service
+apiVersion: v1
+metadata:
+  namespace: test-rabbitmq
+  name: rabbitmq
+  labels:
+    app: rabbitmq
+    type: LoadBalancer  
+spec:
+  type: NodePort
+  ports:
+   - name: http
+     protocol: TCP
+     port: 15672
+     targetPort: 15672
+     nodePort: 31672
+   - name: amqp
+     protocol: TCP
+     port: 5672
+     targetPort: 5672
+     nodePort: 30672
+  selector:
+    app: rabbitmq

--- a/examples/k8s_statefulsets/rabbitmq.yaml
+++ b/examples/k8s_statefulsets/rabbitmq.yaml
@@ -32,7 +32,7 @@ spec:
             command: ["rabbitmqctl", "status"]
           initialDelaySeconds: 10
           timeoutSeconds: 5
-        imagePullPolicy: Never
+        imagePullPolicy: Always
         env:
           - name: MY_POD_IP
             valueFrom:
@@ -42,9 +42,4 @@ spec:
             value: "true"
           - name: RABBITMQ_NODENAME
             value: "rabbit@$(MY_POD_IP)"
-          - name: K8S_ADDRESS_TYPE
-            value: "ip" 
-          - name: CLEANUP_INTERVAL
-            value: "10"
-          - name: CLEANUP_ONLY_LOG_WARNING
-            value: "false"
+ 

--- a/examples/k8s_statefulsets/rabbitmq.yaml
+++ b/examples/k8s_statefulsets/rabbitmq.yaml
@@ -42,4 +42,3 @@ spec:
             value: "true"
           - name: RABBITMQ_NODENAME
             value: "rabbit@$(MY_POD_IP)"
- 

--- a/examples/k8s_statefulsets/rabbitmq.yaml
+++ b/examples/k8s_statefulsets/rabbitmq.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: rabbitmq
+  namespace: test-rabbitmq
+spec:
+  serviceName: rabbitmq
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: rabbitmq
+    spec:
+      terminationGracePeriodSeconds: 10
+      containers:        
+      - name: rabbitmq-k8s
+        image: pivotalrabbitmq/rabbitmq-autocluster:3.7-k8s-BETA
+        ports:
+          - name: http
+            protocol: TCP
+            containerPort: 15672
+          - name: amqp
+            protocol: TCP
+            containerPort: 5672
+        livenessProbe:
+          exec:
+            command: ["rabbitmqctl", "status"]
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        readinessProbe:
+          exec:
+            command: ["rabbitmqctl", "status"]
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+        imagePullPolicy: Never
+        env:
+          - name: MY_POD_IP
+            valueFrom:
+              fieldRef:
+                fieldPath: status.podIP
+          - name: RABBITMQ_USE_LONGNAME
+            value: "true"
+          - name: RABBITMQ_NODENAME
+            value: "rabbit@$(MY_POD_IP)"
+          - name: K8S_ADDRESS_TYPE
+            value: "ip" 
+          - name: CLEANUP_INTERVAL
+            value: "10"
+          - name: CLEANUP_ONLY_LOG_WARNING
+            value: "false"


### PR DESCRIPTION
Implements part of https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s/issues/5

I published the image called [`pivotalrabbitmq/rabbitmq-autocluster:3.7-k8s-BETA`](https://hub.docker.com/r/pivotalrabbitmq/rabbitmq-autocluster/tags/)

_I will remove `BETA` once the RabbitMQ 3.7.x will be out_ 
