### PR TITLE
Add RBAC configuration to example

### DIFF
--- a/examples/k8s_statefulsets/README.md
+++ b/examples/k8s_statefulsets/README.md
@@ -23,7 +23,13 @@ $ minikube start --cpus=2 --memory=2040 --vm-driver=virtualbox
 $ kubectl create namespace test-rabbitmq
 ```
 
-* Deploy the  `YAML` file:
+* Deploy RBAC `YAML` file:
+
+```
+$ kubectl create -f examples/k8s_statefulsets/rabbitmq_rbac.yaml
+```
+
+* Deploy Service/ConfigMap/Statefulset `YAML` file:
 
 ```
 $ kubectl create -f examples/k8s_statefulsets/rabbitmq_statefulsets.yaml

--- a/examples/k8s_statefulsets/README.md
+++ b/examples/k8s_statefulsets/README.md
@@ -23,7 +23,7 @@ $ minikube start --cpus=2 --memory=2040 --vm-driver=virtualbox
 $ kubectl create namespace test-rabbitmq
 ```
 
-* Deploy RBAC `YAML` file:
+* For kubernetes 1.6 or above, RBAC Authorization feature enabled by default. It need configure RBAC related stuff to support access nodes info successfully by plugin. So deploy RBAC `YAML` file():
 
 ```
 $ kubectl create -f examples/k8s_statefulsets/rabbitmq_rbac.yaml

--- a/examples/k8s_statefulsets/rabbitmq_rbac.yaml
+++ b/examples/k8s_statefulsets/rabbitmq_rbac.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rabbitmq 
+  namespace: test-rabbitmq 
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: endpoint-reader
+  namespace: test-rabbitmq 
+rules:
+- apiGroups: [""]
+  resources: ["endpoints"]
+  verbs: ["get"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: endpoint-reader
+  namespace: test-rabbitmq
+subjects:
+- kind: ServiceAccount
+  name: rabbitmq
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: endpoint-reader

--- a/examples/k8s_statefulsets/rabbitmq_statefulsets.yaml
+++ b/examples/k8s_statefulsets/rabbitmq_statefulsets.yaml
@@ -58,6 +58,7 @@ spec:
       labels:
         app: rabbitmq
     spec:
+      serviceAccountName: rabbitmq
       terminationGracePeriodSeconds: 10
       containers:        
       - name: rabbitmq-k8s


### PR DESCRIPTION
This commit fixed the issue: [Need add k8s RBAC configuration for plugin to work correctly](https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s/issues/15)

#### CHANGES
- add RBAC related role/rolebinding/serviceaccount
- add serviceaccountName to rabbitmq_statefulset.yaml
- change README to mention apply rabbitmq_rbac.yaml before applying rabbitmq_statefulset.yaml

