### PR TITLE
Enable namespace_path, cert_path, token_path configuration options

### DIFF
--- a/priv/schema/rabbitmq_peer_discovery_k8s.schema
+++ b/priv/schema/rabbitmq_peer_discovery_k8s.schema
@@ -43,6 +43,10 @@ end}.
 
 %% (ACL) Token path
 
+{mapping, "cluster_formation.k8s.token_path", "rabbit.cluster_formation.peer_discovery_k8s.k8s_token_path", [
+    {datatype, string}
+]}.
+
 {translation, "rabbit.cluster_formation.peer_discovery_k8s.k8s_token_path",
 fun(Conf) ->
     case cuttlefish:conf_get("cluster_formation.k8s.token_path", Conf, undefined) of
@@ -53,6 +57,10 @@ end}.
 
 %% Certificate path
 
+{mapping, "cluster_formation.k8s.cert_path", "rabbit.cluster_formation.peer_discovery_k8s.k8s_cert_path", [
+    {datatype, string}
+]}.
+
 {translation, "rabbit.cluster_formation.peer_discovery_k8s.k8s_cert_path",
 fun(Conf) ->
     case cuttlefish:conf_get("cluster_formation.k8s.cert_path", Conf, undefined) of
@@ -62,6 +70,10 @@ fun(Conf) ->
 end}.
 
 %% Namespace path
+
+{mapping, "cluster_formation.k8s.namespace_path", "rabbit.cluster_formation.peer_discovery_k8s.k8s_namespace_path", [
+    {datatype, string}
+]}.
 
 {translation, "rabbit.cluster_formation.peer_discovery_k8s.k8s_namespace_path",
 fun(Conf) ->


### PR DESCRIPTION
I recently tried configuring the stable/rabbitmq-ha helm chart with explicit configuration items as follows:

cluster_formation.k8s.token_path = /var/run/secrets/kubernetes.io/serviceaccount/token
cluster_formation.k8s.cert_path = /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
cluster_formation.k8s.namespace_path = /var/run/secrets/kubernetes.io/serviceaccount/namespace

which resulted in the error below on rabbitmq:3.7.2 and rabbitmq:3.7.3-rc.1. 

I compiled the plugin and built a new docker image to test that the configuration changes work, but erlang is not my forte at all so please let me know if any changes need to be made.

```BOOT FAILED
===========

Config file generation failed 23:30:41.899 [error] You've tried to set cluster_formation.k8s.token_path, but there is no setting with that name.
23:30:41.899 [error]   Did you mean one of these?
23:30:41.944 [error]     cluster_formation.k8s.host
23:30:41.944 [error]     cluster_formation.k8s.port
23:30:41.944 [error]     cluster_formation.dns.hostname
23:30:41.944 [error] You've tried to set cluster_formation.k8s.cert_path, but there is no setting with that name.
23:30:41.944 [error]   Did you mean one of these?
23:30:41.985 [error]     cluster_formation.k8s.port
23:30:41.985 [error]     cluster_formation.k8s.host
23:30:41.985 [error]     cluster_formation.k8s.service_name
23:30:41.985 [error] You've tried to set cluster_formation.k8s.namespace_path, but there is no setting with that name.
23:30:41.985 [error]   Did you mean one of these?
23:30:42.032 [error]     cluster_formation.k8s.service_name
23:30:42.032 [error]     cluster_formation.k8s.address_type
23:30:42.032 [error]     cluster_formation.k8s.host
23:30:42.033 [error] Error generating configuration in phase transform_datatypes
23:30:42.033 [error] Conf file attempted to set unknown variable: cluster_formation.k8s.namespace_path
23:30:42.033 [error] Conf file attempted to set unknown variable: cluster_formation.k8s.cert_path
23:30:42.033 [error] Conf file attempted to set unknown variable: cluster_formation.k8s.token_path


BOOT FAILED
===========

Error description:
    rabbit:start_it/1 line 448
    rabbit:boot_error/2 line 848
    rabbit_lager:log_locations/0 line 59
    rabbit_lager:ensure_lager_configured/0 line 160
    rabbit_lager:lager_configured/0 line 167
    lager:list_all_sinks/0 line 317
    lager_config:get/2 line 71
    ets:lookup(lager_config, {'_global',handlers})
exit:generate_config_file
Log file(s) (may contain more information):

{"init terminating in do_boot",generate_config_file}
init terminating in do_boot (generate_config_file)

Crash dump is being written to: /var/log/rabbitmq/erl_crash.dump...done```
