### PR TITLE
change probe period from 10s to 60s

### DIFF
--- a/examples/k8s_statefulsets/rabbitmq_statefulsets.yaml
+++ b/examples/k8s_statefulsets/rabbitmq_statefulsets.yaml
@@ -81,12 +81,14 @@ spec:
           exec:
             command: ["rabbitmqctl", "status"]
           initialDelaySeconds: 60
-          timeoutSeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 10
         readinessProbe:
           exec:
             command: ["rabbitmqctl", "status"]
           initialDelaySeconds: 20
-          timeoutSeconds: 60
+          periodSeconds: 60
+          timeoutSeconds: 10
         imagePullPolicy: Always
         env:
           - name: MY_POD_IP


### PR DESCRIPTION
Per [`k8s` probe config docs](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes) `periodSeconds` is what you're really looking for (emphasis added):

>`periodSeconds`: How often (in seconds) to perform the probe. **Default to 10 seconds**. Minimum value is 1.

Fixes #28 

(Shouldn't require a CLA since it's a trivial change?)