### PR TITLE
Bind rabbitmq statefulset to linux nodes to avoid Windows scheduling on kubernetes cluster includes linux nodes and windows nodes

### DIFF
--- a/examples/k8s_statefulsets/rabbitmq_statefulsets.yaml
+++ b/examples/k8s_statefulsets/rabbitmq_statefulsets.yaml
@@ -77,6 +77,8 @@ spec:
     spec:
       serviceAccountName: rabbitmq
       terminationGracePeriodSeconds: 10
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
       - name: rabbitmq-k8s
         image: rabbitmq:3.7


### PR DESCRIPTION
## Proposed Changes

Bind rabbitmq statefulset to linux nodes to avoid Windows scheduling on kubernetes cluster includes linux nodes and windows nodes( since kubernetes 1.14 windows node already ga )

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [x] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc.
