### PR TITLE
Add ipv6 call in the k8s module

### DIFF
--- a/src/rabbit_peer_discovery_k8s.erl
+++ b/src/rabbit_peer_discovery_k8s.erl
@@ -47,7 +47,8 @@ init() ->
     %% we cannot start this plugin yet since it depends on the rabbit app,
     %% which is in the process of being started by the time this function is called
     application:load(rabbitmq_peer_discovery_common),
-    rabbit_peer_discovery_httpc:maybe_configure_proxy().
+    rabbit_peer_discovery_httpc:maybe_configure_proxy(),
+    rabbit_peer_discovery_httpc:maybe_configure_inet6().
 
 -spec list_nodes() -> {ok, {Nodes :: list(), NodeType :: rabbit_types:node_type()}}.
 


### PR DESCRIPTION
## Proposed Changes

Add the `rabbit_peer_discovery_httpc:maybe_configure_inet6().` in the k8s module.

I think is a missing part for https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s/issues/55#event-2738030242

Without this fix didn't work, have the same error for https://github.com/rabbitmq/rabbitmq-peer-discovery-k8s/issues/55

With this fox works:
```
2019-10-24 09:17:54.306 [info] <0.520.0> node 'rabbit@rabbitmq-1.rabbitmq.default.svc.cluster.local' up
2019-10-24 09:17:54.770 [info] <0.520.0> rabbit on node 'rabbit@rabbitmq-1.rabbitmq.default.svc.cluster.local' up
2019-10-24 09:18:54.426 [info] <0.520.0> node 'rabbit@rabbitmq-2.rabbitmq.default.svc.cluster.local' up
2019-10-24 09:18:55.668 [info] <0.520.0> rabbit on node 'rabbit@rabbitmq-2.rabbitmq.default.svc.cluster.local' up
```


## Types of Changes

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

I think this is missing part, unless I missed some point!
In the same way the `rabbit_peer_discovery_httpc:maybe_configure_proxy(),` is called, also the `rabbit_peer_discovery_httpc:maybe_configure_inet6()` is needed to call. 
