### PR TITLE
fixed statefulSet deployment to be compatible to new k8s definition

### DIFF
--- a/examples/k8s_statefulsets/rabbitmq_statefulsets.yaml
+++ b/examples/k8s_statefulsets/rabbitmq_statefulsets.yaml
@@ -59,7 +59,7 @@ data:
       loopback_users.guest = false
 
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 # See the Prerequisites section of https://www.rabbitmq.com/cluster-formation.html#peer-discovery-k8s.
 kind: StatefulSet
 metadata:
@@ -70,6 +70,9 @@ spec:
   # Three nodes is the recommended minimum. Some features may require a majority of nodes
   # to be available.
   replicas: 3
+  selector:
+    matchLabels:
+      app: rabbitmq
   template:
     metadata:
       labels:


### PR DESCRIPTION
## Proposed Changes

minor fix on example k8s yaml file to be compatible with new k8s version. 

## Types of Changes

What types of changes does your code introduce to this project?
_Put an `x` in the boxes that apply_

- [x] Bug fix (non-breaking change which fixes issue #NNNN)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask on the
mailing list. We're here to help! This is simply a reminder of what we are
going to look for before merging your code._

- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [x] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

in the current example, trying to apply to k8s will get following error from definition validator: 

> > error: unable to recognize "rabbitmq_statefulsets.yaml": no matches for kind "StatefulSet" in version "apps/v1beta1"  

  
and 

> > error: error validating "rabbitmq_statefulsets.yaml": error validating data: ValidationError(StatefulSet.spec): missing required field "selector" in io.k8s.api.apps.v1.StatefulSetSpec; if you choose to ignore these errors, turn validation off with --validate=false

this PR is trying to fix this problem. 