### PR TITLE
Add v1.events POC

### DIFF
--- a/src/rabbit_peer_discovery_k8s.erl
+++ b/src/rabbit_peer_discovery_k8s.erl
@@ -86,9 +86,9 @@ unregister() ->
     ok.
 
 -spec post_registration() -> ok | {error, Reason :: string()}.
-
 post_registration() ->
-    send_event("Normal", "Created",  io_lib:format("Node ~s is registered", [node()])), 
+    send_event("Normal", "Created",  
+	       io_lib:format("Node ~s is registered", [node()])), 
     ok.
 
 -spec lock(Node :: atom()) -> not_supported.
@@ -202,27 +202,28 @@ generate_v1_event(NameSpace, Type, Message, Reason) ->
 
 
 generate_v1_event(NameSpace, Name, Type, Message, Reason, EventTime, HostName) ->
- #{
-    metadata => #{
-        namespace => NameSpace,
-        name => list_to_binary(Name)
-    },
-    type => list_to_binary(Type),
-    message => list_to_binary(Message),
-    reason => list_to_binary(Reason),
-    count => 1,
-    lastTimestamp =>  list_to_binary(EventTime),
-    involvedObject => #{
-        apiVersion => <<"v1">>,
-        kind => <<"RabbitMQ">>,
-        name =>  list_to_binary("pod/" ++ HostName),
-        namespace => NameSpace
-    },
-    source => #{
-        component => list_to_binary(HostName ++ "/" ++ ?EVENT_FROM_DESCRIPTION),
-        host => list_to_binary(HostName)
-    }           
- }.
+    #{
+      metadata => #{
+		    namespace => NameSpace,
+		    name => list_to_binary(Name)
+		   },
+      type => list_to_binary(Type),
+      message => list_to_binary(Message),
+      reason => list_to_binary(Reason),
+      count => 1,
+      lastTimestamp =>  list_to_binary(EventTime),
+      involvedObject => #{
+			  apiVersion => <<"v1">>,
+			  kind => <<"RabbitMQ">>,
+			  name =>  list_to_binary("pod/" ++ HostName),
+			  namespace => NameSpace
+			 },
+      source => #{
+		  component => list_to_binary(HostName ++ "/" ++ 
+						  ?EVENT_FROM_DESCRIPTION),
+		  host => list_to_binary(HostName)
+		 }           
+     }.
 
 
 %% @doc Perform a HTTP POST request to K8s to send and k8s v1.Event
@@ -240,27 +241,28 @@ send_event(Type, Reason, Message) ->
     V1Event = generate_v1_event(NameSpace1, Type, Reason, Message),
 
     ?HTTPC_MODULE:post(
-      get_config_key(k8s_scheme, M),
-      get_config_key(k8s_host, M),
-      get_config_key(k8s_port, M),
-      base_path(events,""),
-      [],
-      [{"Authorization", "Bearer " ++ binary_to_list(Token1)}],
-      [{ssl, [{cacertfile, get_config_key(k8s_cert_path, M)}]}],
-        binary_to_list(rabbit_json:encode(V1Event))
+       get_config_key(k8s_scheme, M),
+       get_config_key(k8s_host, M),
+       get_config_key(k8s_port, M),
+       base_path(events,""),
+       [],
+       [{"Authorization", "Bearer " ++ binary_to_list(Token1)}],
+       [{ssl, [{cacertfile, get_config_key(k8s_cert_path, M)}]}],
+       binary_to_list(rabbit_json:encode(V1Event))
       ).  
 
 
 receive_monitoring_messages()->
     receive
         {nodeup, Node} ->
-            send_event("Normal", "NodeUP", io_lib:format("The Node ~s is UP ",[Node]));
+            send_event("Normal", "NodeUP", 
+		       io_lib:format("The Node ~s is UP ",[Node]));
         {nodedown, Node} ->
-            send_event("Warning", "NodeDown", io_lib:format("The Node ~s is Down ",[Node]))
+            send_event("Warning", "NodeDown", 
+		       io_lib:format("The Node ~s is Down ",[Node]))
     end,
     receive_monitoring_messages().
 
 monitor_nodes() ->
     _ = net_kernel:monitor_nodes(true, []),
     receive_monitoring_messages().
-    

--- a/test/rabbitmq_peer_discovery_k8s_SUITE.erl
+++ b/test/rabbitmq_peer_discovery_k8s_SUITE.erl
@@ -37,7 +37,8 @@ groups() ->
                  extract_node_list_with_not_ready_addresses_test,
                  node_name_empty_test,
                  node_name_suffix_test,
-                 registration_support
+                 registration_support,
+                 event_v1_test
                 ]}].
 
 init_per_testcase(T, Config) when T == node_name_empty_test;
@@ -111,3 +112,29 @@ node_name_suffix_test(_Config) ->
     os:putenv("K8S_HOSTNAME_SUFFIX", ".rabbitmq.default.svc.cluster.local"),
     Expectation = 'rabbit@rabbitmq-0.rabbitmq.default.svc.cluster.local',
     ?assertEqual(Expectation, rabbit_peer_discovery_k8s:node_name(<<"rabbitmq-0">>)).
+
+event_v1_test(_Config) ->
+    Expectation = #{
+      count => 1,
+      type => <<"Normal">>,
+      lastTimestamp => <<"2019-12-06T15:10:23+00:00">>,
+      message => <<"MyMessage">>,
+      reason => <<"Reason">>,
+      metadata =>#{
+            name => <<"test">> ,
+            namespace => <<"namespace">>
+        },
+      involvedObject =>#{
+            apiVersion => <<"v1">>,
+            kind => <<"RabbitMQ">>,
+            name => <<"pod/MyHostName">>,
+            namespace => <<"namespace">>
+        },
+      source =>#{
+            component => <<"MyHostName/rabbitmq_peer_discovery">>,
+            host => <<"MyHostName">>
+        }
+    },
+    ?assertEqual(Expectation, 
+    rabbit_peer_discovery_k8s:generate_v1_event(<<"namespace">>, "test",  
+        "Normal", "MyMessage", "Reason", "2019-12-06T15:10:23+00:00", "MyHostName")).

--- a/test/rabbitmq_peer_discovery_k8s_SUITE.erl
+++ b/test/rabbitmq_peer_discovery_k8s_SUITE.erl
@@ -115,26 +115,26 @@ node_name_suffix_test(_Config) ->
 
 event_v1_test(_Config) ->
     Expectation = #{
-      count => 1,
-      type => <<"Normal">>,
-      lastTimestamp => <<"2019-12-06T15:10:23+00:00">>,
-      message => <<"MyMessage">>,
-      reason => <<"Reason">>,
-      metadata =>#{
-            name => <<"test">> ,
-            namespace => <<"namespace">>
-        },
-      involvedObject =>#{
-            apiVersion => <<"v1">>,
-            kind => <<"RabbitMQ">>,
-            name => <<"pod/MyHostName">>,
-            namespace => <<"namespace">>
-        },
-      source =>#{
-            component => <<"MyHostName/rabbitmq_peer_discovery">>,
-            host => <<"MyHostName">>
-        }
-    },
+		    count => 1,
+		    type => <<"Normal">>,
+		    lastTimestamp => <<"2019-12-06T15:10:23+00:00">>,
+		    message => <<"MyMessage">>,
+		    reason => <<"Reason">>,
+		    metadata =>#{
+				 name => <<"test">> ,
+				 namespace => <<"namespace">>
+				},
+		    involvedObject =>#{
+				       apiVersion => <<"v1">>,
+				       kind => <<"RabbitMQ">>,
+				       name => <<"pod/MyHostName">>,
+				       namespace => <<"namespace">>
+				      },
+		    source =>#{
+			       component => <<"MyHostName/rabbitmq_peer_discovery">>,
+			       host => <<"MyHostName">>
+			      }
+		   },
     ?assertEqual(Expectation, 
-    rabbit_peer_discovery_k8s:generate_v1_event(<<"namespace">>, "test",  
-        "Normal", "MyMessage", "Reason", "2019-12-06T15:10:23+00:00", "MyHostName")).
+		 rabbit_peer_discovery_k8s:generate_v1_event(<<"namespace">>, "test",  
+							     "Normal", "MyMessage", "Reason", "2019-12-06T15:10:23+00:00", "MyHostName")).


### PR DESCRIPTION
## Proposed Changes
Please consider this PR as a proposal.

The idea is to add the k8s [`v1.Event`](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#event-v1-core) on this plugin

So in this way, the events are exposed to a "watchers" (or an operator) or on the Dashboard, that's would be the output:

```bash
$  kubectl get events
<unknown>   Normal    Created                                      Node rabbit@rabbitmq-op-0.rabbitmq-op.default.svc.cluster.local, registered
<unknown>   Normal    NodeUP                                       The Node rabbit@rabbitmq-op-3.rabbitmq-op.default.svc.cluster.local is UP,
<unknown>   Normal    NodeUP                                       The Node rabbit@rabbitmq-op-2.rabbitmq-op.default.svc.cluster.local is UP,
<unknown>   Normal    NodeUP                                       The Node rabbit@rabbitmq-op-1.rabbitmq-op.default.svc.cluster.local is UP,
<unknown>   Normal    Created                                      Node rabbit@rabbitmq-op-0.rabbitmq-op.default.svc.cluster.local, registered
<unknown>   Normal    NodeDown                                     The Node rabbit@rabbitmq-op-3.rabbitmq-op.default.svc.cluster.local is Down,
<unknown>   Normal    NodeUP                                       The Node rabbit@rabbitmq-op-3.rabbitmq-op.default.svc.cluster.local is UP,
```

## Types of Changes

- [ ] Bug fix (non-breaking change which fixes issue #NNNN)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause an observable behavior change in existing systems)
- [ ] Documentation improvements (corrections, new content, etc)
- [ ] Cosmetic change (whitespace, formatting, etc)

## Checklist
- [x] I have read the `CONTRIBUTING.md` document
- [x] I have signed the CA (see https://cla.pivotal.io/sign/rabbitmq)
- [ ] All tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in related repositories

## Further Comments

Note:
This feature requires the following rule:
```yaml
rules:
- apiGroups: 
    - ""
  resources: 
    - events
  verbs: 
    - create
```

This PR requires more work, I didn't want to go to much ahead, I wanted to know your opinion on it.
Feel free to close/ignore it :)!  
